### PR TITLE
Ignore more files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@
 # System image
 uImage
 
+# Build directories
+OBJ/
+
 # Debug files
 *.dSYM/
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 *.x86_64
 *.hex
 
+# System image
+uImage
+
 # Debug files
 *.dSYM/
 


### PR DESCRIPTION
Ignoring `OBJ/` and `uImage` that can be built from source.
