### PR TITLE
Fix ARM EXIDX warnings

### DIFF
--- a/target/ev3_gcc/dmloader/app/app.ld
+++ b/target/ev3_gcc/dmloader/app/app.ld
@@ -53,13 +53,16 @@ SECTIONS
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
     } : text
+
+    . = ALIGN(4);
+
+    __exidx_start = .;
     .ARM.exidx :
     {
-        . = ALIGN(4);
-        __exidx_start = .;
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-        __exidx_end = .;
     } : text
+    __exidx_end = .;
+
     .rel.plt :
     {
      __dummy_rel_plt = .;

--- a/target/ev3_gcc/dmloader/src/elf32.c
+++ b/target/ev3_gcc/dmloader/src/elf32.c
@@ -108,8 +108,9 @@ enum SectionType {
 };
 
 enum SegmentType {
-    PT_NULL = 0,
-    PT_LOAD = 1
+    PT_NULL      = 0x00000000,
+    PT_LOAD      = 0x00000001,
+    PT_ARM_EXIDX = 0x70000001
 };
 
 enum SegmentPermission {
@@ -274,7 +275,7 @@ ER elf32_load(const void *elf32_data, uint32_t elf32_data_sz, elf32_ldctx_t *ctx
         const Elf32_Phdr *phdr = ELF32_PHDR(ehdr, i);
 
         // Skip if not PT_LOAD segment
-        if(phdr->p_type == PT_NULL) continue;
+        if(phdr->p_type == PT_NULL || phdr->p_type == PT_ARM_EXIDX) continue;
         if(phdr->p_type != PT_LOAD) {
             syslog(LOG_WARNING, "%s(): Unsupported segment type %d.", __FUNCTION__, phdr->p_type);
             continue;


### PR DESCRIPTION
GCC on Ubuntu generates extra exception handling sections in the ELF file. This PR fixes linker warning looking like this: [stackoverflow.com/questions/45816655](https://stackoverflow.com/questions/45816655/how-to-properly-avoid-warning-about-sh-link-not-set-for-section-arm-exidx). It also fixes warning from module loader about an unknown section (source [here](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044f/IHI0044F_aaelf.pdf)).
GCC version:
```
arm-none-eabi-gcc (15:4.9.3+svn231177-1) 4.9.3 20150529 (prerelease)
```

Linker version:
```
GNU ld (2.26-4ubuntu1+8) 2.26
```
Suprisingly, the warning doesn't always show up.